### PR TITLE
XWP Coding Challenge - Fix render_callback() method in XWP\SiteCounts\Block.php

### DIFF
--- a/php/Block.php
+++ b/php/Block.php
@@ -61,33 +61,24 @@ class Block {
 	 * @param WP_Block $block      The instance of this block.
 	 * @return string The markup of the block.
 	 */
-	public function render_callback( $attributes, $content, $block ) {
+	public function render_callback( $attributes, $content, $block )
+	{
 		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = $attributes['className'];
-		ob_start();
+		// ob_start();
+		$block_markup = sprintf('<div class="%1$s"><h2>%2$s</h2>', $class_name, __('Post Counts', 'sitecounts') );
 
-		?>
-		<div class="<?php echo $class_name; ?>">
-			<h2>Post Counts</h2>
-			<?php
-			foreach ( $post_types as $post_type_slug ) :
-				$post_type_object = get_post_type_object( $post_type_slug );
-				$post_count = count(
-					get_posts(
-						[
-							'post_type' => $post_type_slug,
-							'posts_per_page' => -1,
-						]
-					)
-				);
+		array_walk( $post_types, function($v, $k) use (&$block_markup) {
+			$post_type_object = get_post_type_object( $v );
+			$post_type_labels = get_post_type_labels( $post_type_object );
+			$post_type_count = wp_count_posts( $post_type_labels->name );
 
-				?>
-				<p><?php echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name . '.'; ?></p>
-			<?php endforeach; ?>
-			<p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
-		</div>
-		<?php
+			$block_markup .= sprintf('<p>%1$s %2$d %3$s.</p>', _n('There is', 'There are', $post_type_count, 'sitecounts'), $post_type_count, $post_type_labels->name );
+		});
 
-		return ob_get_clean();
+		$block_markup .=  sprintf('<p>The current post ID is %s.</p>', sanitize_text_field( $_GET['post_id'] ) );
+
+		//return ob_get_clean();
+		return $block_markup;
 	}
 }

--- a/php/Block.php
+++ b/php/Block.php
@@ -65,20 +65,19 @@ class Block {
 	{
 		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = $attributes['className'];
-		// ob_start();
+
 		$block_markup = sprintf('<div class="%1$s"><h2>%2$s</h2>', $class_name, __('Post Counts', 'sitecounts') );
 
 		array_walk( $post_types, function($v, $k) use (&$block_markup) {
-			$post_type_object = get_post_type_object( $v );
-			$post_type_labels = get_post_type_labels( $post_type_object );
-			$post_type_count = wp_count_posts( $post_type_labels->name );
+		$post_type_object = get_post_type_object( $v );
+		$post_type_labels = get_post_type_labels( $post_type_object );
+		$post_type_count = wp_count_posts( $post_type_labels->name );
 
-			$block_markup .= sprintf('<p>%1$s %2$d %3$s.</p>', _n('There is', 'There are', $post_type_count, 'sitecounts'), $post_type_count, $post_type_labels->name );
+		$block_markup .= sprintf('<p>%1$s %2$d %3$s.</p>', _n('There is', 'There are', $post_type_count, 'sitecounts'), $post_type_count, _n( $post_type_labels->singular_name, $post_type_labels->name, $post_type_count, 'sitecounts' ) );
 		});
 
-		$block_markup .=  sprintf('<p>The current post ID is %s.</p>', sanitize_text_field( $_GET['post_id'] ) );
+		$block_markup .=  sprintf('<p>The current post ID is %s.</p>', sanitize_text_field( strval($_GET['post_id']) ) );
 
-		//return ob_get_clean();
-		return $block_markup;
+		return apply_filters( 'sitecounts_block_markup', $block_markup, $post_type_count, $post_type_labels );
 	}
 }

--- a/php/Block.php
+++ b/php/Block.php
@@ -64,20 +64,20 @@ class Block {
 	public function render_callback( $attributes, $content, $block )
 	{
 		$post_types = get_post_types( [ 'public' => true ] );
-		$class_name = $attributes['className'];
+		$class_name = array_key_exists( 'className', $attributes ) ? esc_attr( strval( $attributes['className'] ) ) : '';
 
 		$block_markup = sprintf('<div class="%1$s"><h2>%2$s</h2>', $class_name, __('Post Counts', 'sitecounts') );
 
 		array_walk( $post_types, function($v, $k) use (&$block_markup) {
-		$post_type_object = get_post_type_object( $v );
-		$post_type_labels = get_post_type_labels( $post_type_object );
-		$post_type_count = wp_count_posts( $post_type_labels->name );
+			$post_type_object = get_post_type_object( $v );
+			$post_type_labels = get_post_type_labels( $post_type_object );
+			$post_type_counts = wp_count_posts( $post_type_labels->name );
 
-		$block_markup .= sprintf('<p>%1$s %2$d %3$s.</p>', _n('There is', 'There are', $post_type_count, 'sitecounts'), $post_type_count, _n( $post_type_labels->singular_name, $post_type_labels->name, $post_type_count, 'sitecounts' ) );
+			$block_markup .= sprintf('<p>%1$s %2$d %3$s.</p>', _n('There is', 'There are', $post_type_counts, 'sitecounts'), $post_type_counts, _n( $post_type_labels->singular_name, $post_type_labels->name, $post_type_counts, 'sitecounts' ) );
 		});
 
 		$block_markup .=  sprintf('<p>The current post ID is %s.</p>', sanitize_text_field( strval($_GET['post_id']) ) );
 
-		return apply_filters( 'sitecounts_block_markup', $block_markup, $post_type_count, $post_type_labels );
+		return apply_filters( 'sitecounts_block_markup', $block_markup, $post_type_counts, $post_type_labels );
 	}
 }


### PR DESCRIPTION
- replace output buffering and echo statements with a builder pattern implemented using array_walk.
- replace WP_Query wrapper function get_posts with a builtin utility function wp_count_posts. -1 in get_posts will not scale.
- replace string literals with translatable equivalents, including plural translations.
- sanitize query argument in $_GET for safe input.
- declare filter hook 'sitecounts_block_markup' for customization.